### PR TITLE
Add minimal Express server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "testapp1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/hello', (req, res) => {
+  res.json({ message: 'Hello, world!' });
+});
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add Express server with `/hello` endpoint
- add `package.json` with Express dependency

## Testing
- `npm install express` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_685af2339528833083ddb7aeb147c943