### PR TITLE
Add Layout component and use in calculator pages

### DIFF
--- a/public/apps/bmi-calculator/bmi-calculator.js
+++ b/public/apps/bmi-calculator/bmi-calculator.js
@@ -1,0 +1,65 @@
+const { useState } = React;
+
+function BMICalculator() {
+  const [weight, setWeight] = useState('');
+  const [height, setHeight] = useState('');
+  const [bmi, setBmi] = useState(null);
+
+  const calculateBMI = () => {
+    const w = parseFloat(weight);
+    const h = parseFloat(height);
+    if (isNaN(w) || isNaN(h) || w <= 0 || h <= 0) {
+      setBmi(null);
+      return;
+    }
+    const hMeters = h / 100;
+    setBmi(w / (hMeters * hMeters));
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold text-center mb-4">BMI Calculator</h1>
+      <div className="bg-gray-100 p-4 rounded neo space-y-4">
+        <div className="space-y-2">
+          <label className="block">Weight (kg)</label>
+          <input
+            type="number"
+            className="w-full p-2 rounded border neo"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block">Height (cm)</label>
+          <input
+            type="number"
+            className="w-full p-2 rounded border neo"
+            value={height}
+            onChange={(e) => setHeight(e.target.value)}
+          />
+        </div>
+        <button
+          className="w-full p-2 bg-blue-500 text-white rounded neo"
+          onClick={calculateBMI}
+        >
+          Calculate
+        </button>
+      </div>
+      {bmi && (
+        <div className="bg-gray-100 p-4 rounded neo">
+          Your BMI: <span className="font-semibold">{bmi.toFixed(2)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ReactDOM.render(
+  <Layout>
+    <div className="w-full max-w-md">
+      <BMICalculator />
+    </div>
+  </Layout>,
+  document.getElementById('root')
+);
+

--- a/public/apps/bmi-calculator/index.html
+++ b/public/apps/bmi-calculator/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>EMI Calculator</title>
+  <title>BMI Calculator</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <style>
     .neo {
@@ -12,13 +12,13 @@
     }
   </style>
 </head>
- <body class="bg-gray-100">
-   <div id="root"></div>
+<body class="bg-gray-100">
+  <div id="root"></div>
 
   <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
-   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
-   <script type="text/babel" src="../../components/Layout.js"></script>
-   <script type="text/babel" src="emi-calculator.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel" src="../../components/Layout.js"></script>
+  <script type="text/babel" src="bmi-calculator.js"></script>
 </body>
 </html>

--- a/public/apps/emi-calculator/emi-calculator.js
+++ b/public/apps/emi-calculator/emi-calculator.js
@@ -84,4 +84,11 @@ function EMICalculator() {
   );
 }
 
-ReactDOM.render(<EMICalculator />, document.getElementById('root'));
+ReactDOM.render(
+  <Layout>
+    <div className="w-full max-w-md">
+      <EMICalculator />
+    </div>
+  </Layout>,
+  document.getElementById('root')
+);

--- a/public/components/Layout.js
+++ b/public/components/Layout.js
@@ -1,0 +1,16 @@
+function Layout({ children }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="p-4 bg-gray-100 neo text-center font-bold text-xl">
+        Apps That Matter
+      </header>
+      <main className="flex-1 p-4 flex flex-col items-center">
+        {children}
+      </main>
+      <footer className="p-4 bg-gray-100 neo text-center">
+        &copy; {new Date().getFullYear()} Apps That Matter
+      </footer>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create `Layout` component for shared header and footer
- update EMI calculator page to wrap content with `Layout`
- add BMI calculator page using the new `Layout`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b01e2c2308330a4bc7128644ccff9