### PR TITLE
Add neumorphic landing page

### DIFF
--- a/public/landing.html
+++ b/public/landing.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Apps That Matter</title>
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Custom neumorphic style -->
+  <style>
+    .neo {
+      box-shadow: 6px 6px 12px #d1d9e6,
+                  -6px -6px 12px #ffffff;
+    }
+  </style>
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <!-- Header -->
+  <header class="p-4 text-center font-bold text-xl bg-gray-100 neo">
+    Apps That Matter
+  </header>
+
+  <!-- Search bar and category filter -->
+  <main class="p-4">
+    <div class="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2">
+      <input id="search" type="text" placeholder="Search apps..."
+        class="flex-1 p-2 rounded-xl neo focus:outline-none" />
+      <select id="categoryFilter" class="p-2 rounded-xl neo">
+        <option value="">All Categories</option>
+      </select>
+    </div>
+
+    <!-- Card layout -->
+    <div id="appList" class="mt-4 grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+      <!-- App cards injected here -->
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="p-4 mt-4 text-center bg-gray-100 neo">
+    &copy; <span id="year"></span> Apps That Matter
+  </footer>
+
+  <!-- JavaScript logic -->
+  <script>
+    // Sample app data
+    const apps = [
+      { icon: '📈', name: 'EMI Calculator', description: 'Calculate your loan EMI quickly.', category: 'Finance' },
+      { icon: '💪', name: 'BMI Calculator', description: 'Check your body mass index.', category: 'Health' },
+      { icon: '📝', name: 'Notes', description: 'Simple note-taking app.', category: 'Productivity' },
+      { icon: '🗓️', name: 'Task Manager', description: 'Organize your tasks efficiently.', category: 'Productivity' },
+      { icon: '💰', name: 'Budget Tracker', description: 'Track your expenses and income.', category: 'Finance' },
+      { icon: '🌤️', name: 'Weather Now', description: 'Get the latest weather updates.', category: 'Utility' },
+    ];
+
+    const appList = document.getElementById('appList');
+    const searchInput = document.getElementById('search');
+    const categoryFilter = document.getElementById('categoryFilter');
+    const yearSpan = document.getElementById('year');
+
+    // populate category dropdown
+    const categories = [...new Set(apps.map(app => app.category))];
+    categories.forEach(cat => {
+      const option = document.createElement('option');
+      option.value = cat;
+      option.textContent = cat;
+      categoryFilter.appendChild(option);
+    });
+
+    // render apps based on search and category filter
+    function renderApps() {
+      const searchTerm = searchInput.value.toLowerCase();
+      const selectedCategory = categoryFilter.value;
+
+      appList.innerHTML = '';
+
+      apps.filter(app => {
+        const matchesName = app.name.toLowerCase().includes(searchTerm);
+        const matchesCategory = selectedCategory ? app.category === selectedCategory : true;
+        return matchesName && matchesCategory;
+      }).forEach(app => {
+        const card = document.createElement('div');
+        card.className = 'neo p-4 rounded-xl space-y-2 bg-gray-100 transition hover:-translate-y-1 hover:shadow-lg';
+        card.innerHTML = `
+          <div class="text-3xl">${app.icon}</div>
+          <h2 class="text-lg font-semibold">${app.name}</h2>
+          <p class="text-sm text-gray-700">${app.description}</p>
+          <span class="inline-block px-2 py-1 text-xs bg-blue-100 text-blue-600 rounded-full">${app.category}</span>
+        `;
+        appList.appendChild(card);
+      });
+    }
+
+    // event listeners for live filtering
+    searchInput.addEventListener('input', renderApps);
+    categoryFilter.addEventListener('change', renderApps);
+
+    // init footer year and initial render
+    yearSpan.textContent = new Date().getFullYear();
+    renderApps();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone landing page at `public/landing.html`
- implement header, search, filter, and cards with neumorphic Tailwind styles
- provide inline JavaScript for live search and filter

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b7c2e171483308b9f334dd0c8bf03